### PR TITLE
Change default user model to model from config

### DIFF
--- a/src/ChatMessengerServiceProvider.php
+++ b/src/ChatMessengerServiceProvider.php
@@ -95,8 +95,8 @@ class ChatMessengerServiceProvider extends ServiceProvider
     {
         $config = $this->app->make('config');
 
-        $model = $config->get('auth.providers.users.model', function () use ($config) {
-            return $config->get('auth.model', $config->get('chatmessenger.user_model'));
+        $model = $config->get('chatmessenger.user_model') ?? $config->get('auth.providers.users.model', function () use ($config) {
+            return $config->get('auth.model');
         });
 
         Models::setUserModel($model);


### PR DESCRIPTION
We have multiple user types in our project. We also use the default Auth from Laravel. But in chat we use different user - however if we define the user model in config, the default Auth user model from Laravel has the priority which is not a good solution imho. Configurable properties should have priority if defined. 